### PR TITLE
Bump com.gradle.enterprise from 3.11.1 to 3.15

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@
  */
 
 plugins {
-    id "com.gradle.enterprise" version "3.11.1"
+    id "com.gradle.enterprise" version "3.15"
 }
 
 gradleEnterprise {


### PR DESCRIPTION
Bumps com.gradle.enterprise from 3.11.1 to 3.15.

---
updated-dependencies:
- dependency-name: com.gradle.enterprise dependency-type: direct:production update-type: version-update:semver-minor ...

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
